### PR TITLE
Report a per-node size

### DIFF
--- a/azimuth_capi/builder.py
+++ b/azimuth_capi/builder.py
@@ -211,7 +211,7 @@ class ClusterStatusBuilder:
         self.status.kubernetes_version = None
         return self
 
-    def machine_updated(self, obj):
+    def machine_updated(self, obj, infra_machine):
         """
         Updates the status when a CAPI machine is updated.
         """
@@ -238,6 +238,8 @@ class ClusterStatusBuilder:
             # The node role should be in the labels
             role = NodeRole(labels["capi.stackhpc.com/component"]),
             phase = node_phase,
+            # This assumes an OpenStackMachine for now
+            size = infra_machine.spec.flavor,
             ip = next(
                 (
                     a["address"]

--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -213,6 +213,10 @@ class NodeStatus(BaseModel):
         NodePhase.UNKNOWN.value,
         description = "The phase of the node."
     )
+    size: t.Optional[constr(min_length = 1)] = Field(
+        None,
+        description = "The name of the size of the machine."
+    )
     ip: t.Optional[str] = Field(
         None,
         description = "The internal IP address of the node."


### PR DESCRIPTION
So that accurate sizes can be determined for pre-existing nodes (which will be replaced) when a node group's size is changed