### PR TITLE
Use multi-stage Dockerfile with baked in charts

### DIFF
--- a/.github/workflows/build-push-artifacts.yaml
+++ b/.github/workflows/build-push-artifacts.yaml
@@ -15,6 +15,19 @@ on:
         description: The chart version that was published
         value: ${{ jobs.build_push_chart.outputs.chart-version }}
 
+# Variables controlling the dependencies that are baked in to the image
+env:
+  HELM_VERSION: v3.13.2
+  # CAPI Helm chart
+  OPENSTACK_CLUSTER_CHART_REPO: https://stackhpc.github.io/capi-helm-charts
+  OPENSTACK_CLUSTER_CHART_NAME: openstack-cluster
+  OPENSTACK_CLUSTER_CHART_VERSION: 0.1.4
+  # Zenith charts
+  ZENITH_CHART_REPO: https://stackhpc.github.io/zenith
+  ZENITH_CHART_VERSION: 0.1.0
+  ZENITH_APISERVER_CHART_NAME: zenith-apiserver
+  ZENITH_OPERATOR_CHART_NAME: zenith-operator
+
 jobs:
   build_push_images:
     name: Build and push images
@@ -47,6 +60,8 @@ jobs:
           cache-key: azimuth-capi-operator
           context: .
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            HELM_VERSION=${{ env.HELM_VERSION }}
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/build-push-artifacts.yaml
+++ b/.github/workflows/build-push-artifacts.yaml
@@ -62,6 +62,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             HELM_VERSION=${{ env.HELM_VERSION }}
+            OPENSTACK_CLUSTER_CHART_REPO=${{ env.OPENSTACK_CLUSTER_CHART_REPO }}
+            OPENSTACK_CLUSTER_CHART_NAME=${{ env.OPENSTACK_CLUSTER_CHART_NAME }}
+            OPENSTACK_CLUSTER_CHART_VERSION=${{ env.OPENSTACK_CLUSTER_CHART_VERSION }}
+            ZENITH_CHART_REPO=${{ env.ZENITH_CHART_REPO }}
+            ZENITH_CHART_VERSION=${{ env.ZENITH_CHART_VERSION }}
+            ZENITH_APISERVER_CHART_NAME=${{ env.ZENITH_APISERVER_CHART_NAME }}
+            ZENITH_OPERATOR_CHART_NAME=${{ env.ZENITH_OPERATOR_CHART_NAME }}
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,11 @@ RUN python3 -m venv /venv && \
 COPY requirements.txt /app/requirements.txt
 RUN /venv/bin/pip install --no-deps --requirement /app/requirements.txt
 
+# Jinja2 complains if this is installed the "regular" way
+# https://jinja.palletsprojects.com/en/3.1.x/api/#loaders
+# So we install here instead as an editable installation and also copy over the app directory
 COPY . /app
-RUN /venv/bin/pip install --no-deps /app
+RUN /venv/bin/pip install --no-deps -e /app
 
 
 FROM ubuntu:jammy
@@ -91,6 +94,7 @@ RUN apt-get update && \
 COPY --from=helm /usr/bin/helm /usr/bin/helm
 COPY --from=helm /charts /charts
 COPY --from=python-builder /venv /venv
+COPY --from=python-builder /app /app
 
 USER $APP_UID
 ENTRYPOINT ["/usr/bin/tini", "-g", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,74 @@
-FROM python:3.9
+FROM ubuntu:jammy as helm
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG HELM_VERSION
+RUN set -ex; \
+    OS_ARCH="$(uname -m)"; \
+    case "$OS_ARCH" in \
+        x86_64) helm_arch=amd64 ;; \
+        aarch64) helm_arch=arm64 ;; \
+        *) false ;; \
+    esac; \
+    curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${helm_arch}.tar.gz | \
+      tar -xz --strip-components 1 -C /usr/bin linux-${helm_arch}/helm; \
+    helm version
+
+# Pull and unpack the baked in charts
+ARG OPENSTACK_CLUSTER_CHART_REPO
+ARG OPENSTACK_CLUSTER_CHART_NAME
+ARG OPENSTACK_CLUSTER_CHART_VERSION
+RUN helm pull ${OPENSTACK_CLUSTER_CHART_NAME} \
+      --repo ${OPENSTACK_CLUSTER_CHART_REPO} \
+      --version ${OPENSTACK_CLUSTER_CHART_VERSION} \
+      --untar \
+      --untardir /charts && \
+    rm -rf /charts/*.tgz
+
+ARG ZENITH_CHART_REPO
+ARG ZENITH_CHART_VERSION
+ARG ZENITH_APISERVER_CHART_NAME
+ARG ZENITH_OPERATOR_CHART_NAME
+RUN helm pull ${ZENITH_APISERVER_CHART_NAME} \
+      --repo ${ZENITH_CHART_REPO} \
+      --version ${ZENITH_CHART_VERSION} \
+      --untar \
+      --untardir /charts && \
+    helm pull ${ZENITH_OPERATOR_CHART_NAME} \
+      --repo ${ZENITH_CHART_REPO} \
+      --version ${ZENITH_CHART_VERSION} \
+      --untar \
+      --untardir /charts && \
+    rm -rf /charts/*.tgz
+
+
+FROM ubuntu:jammy AS python-builder
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /venv && \
+    /venv/bin/pip install -U pip setuptools
+
+COPY requirements.txt /app/requirements.txt
+RUN /venv/bin/pip install --no-deps --requirement /app/requirements.txt
+
+COPY . /app
+RUN /venv/bin/pip install --no-deps /app
+
+
+FROM ubuntu:jammy
+
+# Don't buffer stdout and stderr as it breaks realtime logging
+ENV PYTHONUNBUFFERED 1
+
+# Tell Helm to use /tmp for mutable data
+ENV HELM_CACHE_HOME /tmp/helm/cache
+ENV HELM_CONFIG_HOME /tmp/helm/config
+ENV HELM_DATA_HOME /tmp/helm/data
 
 # Create the user that will be used to run the app
 ENV APP_UID 1001
@@ -14,40 +84,14 @@ RUN groupadd --gid $APP_GID $APP_GROUP && \
       --uid $APP_UID \
       $APP_USER
 
-# Install tini, which we will use to marshal the processes
 RUN apt-get update && \
-    apt-get install -y tini && \
+    apt-get install --no-install-recommends --no-install-suggests -y ca-certificates python3 tini && \
     rm -rf /var/lib/apt/lists/*
 
-# Don't buffer stdout and stderr as it breaks realtime logging
-ENV PYTHONUNBUFFERED 1
+COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY --from=helm /charts /charts
+COPY --from=python-builder /venv /venv
 
-# The operator calls out to the Helm CLI, so install that
-ENV HELM_CACHE_HOME /tmp/helm/cache
-ENV HELM_CONFIG_HOME /tmp/helm/config
-ENV HELM_DATA_HOME /tmp/helm/data
-ARG HELM_VERSION=v3.11.2
-RUN set -ex; \
-    OS_ARCH="$(uname -m)"; \
-    case "$OS_ARCH" in \
-        x86_64) helm_arch=amd64 ;; \
-        aarch64) helm_arch=arm64 ;; \
-        *) false ;; \
-    esac; \
-    curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${helm_arch}.tar.gz | \
-      tar -xz --strip-components 1 -C /usr/bin linux-${helm_arch}/helm; \
-    helm version
-
-# Install dependencies
-# Doing this separately by copying only the requirements file enables better use of the build cache
-COPY ./requirements.txt /application/
-RUN pip install --no-deps --requirement /application/requirements.txt
-
-# Install the perftest package
-COPY . /application
-RUN pip install --no-deps -e /application
-
-# By default, run the operator using kopf
 USER $APP_UID
-ENTRYPOINT ["tini", "-g", "--"]
-CMD ["kopf", "run", "--module", "azimuth_capi.operator", "--all-namespaces"]
+ENTRYPOINT ["/usr/bin/tini", "-g", "--"]
+CMD ["/venv/bin/kopf", "run", "--module", "azimuth_capi.operator", "--all-namespaces"]

--- a/azimuth_capi/config.py
+++ b/azimuth_capi/config.py
@@ -52,12 +52,11 @@ class CAPIHelmConfig(Section):
     """
     Configuration for the CAPI Helm chart used to deploy clusters.
     """
-    #: The repository containing the CAPI Helm charts
-    chart_repository: AnyHttpUrl = "https://stackhpc.github.io/capi-helm-charts"
-    #: The name of the CAPI Helm chart to use to deploy clusters
-    chart_name: constr(min_length = 1) = "openstack-cluster"
-    #: The version of the CAPI Helm chart to use to deploy clusters
-    chart_version: SemVerVersion = "0.1.4"
+    #: The Helm chart repo, name and version to use for the CAPI Helm charts
+    #: By default, this points to a local chart that is baked into the Docker image
+    chart_name: constr(min_length = 1) = "/charts/openstack-cluster"
+    chart_repository: t.Optional[AnyHttpUrl] = None
+    chart_version: t.Optional[SemVerVersion] = None
     #: The default values to use for all clusters
     #: Values defined in templates take precedence
     default_values: t.Dict[str, t.Any] = Field(default_factory = dict)
@@ -78,12 +77,12 @@ class ZenithConfig(Section):
     #: The port for the Zenith SSHD service
     sshd_port: conint(gt = 0) = 22
 
-    #: The repository for the Zenith charts
-    chart_repository: AnyHttpUrl = "https://stackhpc.github.io/zenith"
-    #: The version of the charts to use
-    #: When changing this, be aware that the operator may depend on the layout of
-    #: the Helm values at a particular version
-    chart_version: SemVerVersion = "0.1.1-dev.0.feature-migrate-to-pydantic2.9"
+    #: The Zenith chart repository, version and names
+    #: By default, these point to local charts that are baked into the Docker image
+    apiserver_chart_name: constr(min_length = 1) = "/charts/zenith-apiserver"
+    operator_chart_name: constr(min_length = 1) = "/charts/zenith-operator"
+    chart_repository: t.Optional[AnyHttpUrl] = None
+    chart_version: t.Optional[SemVerVersion] = None
 
     #: Defaults for use with the apiserver chart
     apiserver_defaults: t.Dict[str, t.Any] = Field(default_factory = dict)

--- a/azimuth_capi/zenith.py
+++ b/azimuth_capi/zenith.py
@@ -107,7 +107,7 @@ async def zenith_apiserver_values(client, cluster):
     resources = list(
         await client.template_resources(
             await client.get_chart(
-                "zenith-apiserver",
+                settings.zenith.apiserver_chart_name,
                 repo = settings.zenith.chart_repository,
                 version = settings.zenith.chart_version
             ),
@@ -262,7 +262,7 @@ async def zenith_operator_resources(name, namespace, cloud_credentials_secret):
     return list(
         await client.template_resources(
             await client.get_chart(
-                "zenith-operator",
+                settings.zenith.operator_chart_name,
                 repo = settings.zenith.chart_repository,
                 version = settings.zenith.chart_version
             ),


### PR DESCRIPTION
Using a multi-stage Dockerfile allows us to reduce the size and number of vulnerabilities in the final image.

Using baked in charts means we don't have to download the same chart multiple times during operation.

Also closes #38.