### PR TITLE
Use build-arg defaults for chart versions

### DIFF
--- a/.github/workflows/build-push-artifacts.yaml
+++ b/.github/workflows/build-push-artifacts.yaml
@@ -21,14 +21,6 @@ on:
         description: The chart version that was published
         value: ${{ jobs.build_push_chart.outputs.chart-version }}
 
-# Variables controlling the dependencies that are baked in to the image
-env:
-  HELM_VERSION: v3.13.3
-  # CAPI Helm chart
-  OPENSTACK_CLUSTER_CHART_VERSION: 0.1.8
-  # Zenith charts
-  ZENITH_CHART_VERSION: 0.3.1
-
 jobs:
   build_push_images:
     name: Build and push images
@@ -63,10 +55,6 @@ jobs:
           cache-key: azimuth-capi-operator
           context: .
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            HELM_VERSION=${{ env.HELM_VERSION }}
-            OPENSTACK_CLUSTER_CHART_VERSION=${{ env.OPENSTACK_CLUSTER_CHART_VERSION }}
-            ZENITH_CHART_VERSION=${{ env.ZENITH_CHART_VERSION }}
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -15,21 +15,21 @@ jobs:
       matrix:
         include:
           - key: helm
-            path: ./.github/workflows/build-push-artifacts.yaml
+            path: ./Dockerfile
             repository: helm/helm
-            version_jsonpath: env.HELM_VERSION
+            version_jsonpath: HELM_VERSION
 
           - key: openstack-cluster
-            path: ./.github/workflows/build-push-artifacts.yaml
+            path: ./Dockerfile
             repository: stackhpc/capi-helm-charts
             prereleases: "yes"
-            version_jsonpath: env.OPENSTACK_CLUSTER_CHART_VERSION
+            version_jsonpath: OPENSTACK_CLUSTER_CHART_VERSION
 
           - key: zenith
-            path: ./.github/workflows/build-push-artifacts.yaml
+            path: ./Dockerfile
             repository: stackhpc/zenith
             prereleases: "yes"
-            version_jsonpath: env.ZENITH_CHART_VERSION
+            version_jsonpath: ZENITH_CHART_VERSION
 
     name: ${{ matrix.key }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION
+ARG HELM_VERSION=v3.13.3
 RUN set -ex; \
     OS_ARCH="$(uname -m)"; \
     case "$OS_ARCH" in \
@@ -19,7 +19,7 @@ RUN set -ex; \
 # Pull and unpack the baked in charts
 ARG OPENSTACK_CLUSTER_CHART_REPO=https://stackhpc.github.io/capi-helm-charts
 ARG OPENSTACK_CLUSTER_CHART_NAME=openstack-cluster
-ARG OPENSTACK_CLUSTER_CHART_VERSION
+ARG OPENSTACK_CLUSTER_CHART_VERSION=0.1.8
 RUN helm pull ${OPENSTACK_CLUSTER_CHART_NAME} \
       --repo ${OPENSTACK_CLUSTER_CHART_REPO} \
       --version ${OPENSTACK_CLUSTER_CHART_VERSION} \
@@ -28,7 +28,7 @@ RUN helm pull ${OPENSTACK_CLUSTER_CHART_NAME} \
     rm -rf /charts/*.tgz
 
 ARG ZENITH_CHART_REPO=https://stackhpc.github.io/zenith
-ARG ZENITH_CHART_VERSION
+ARG ZENITH_CHART_VERSION=0.3.1
 ARG ZENITH_APISERVER_CHART_NAME=zenith-apiserver
 ARG ZENITH_OPERATOR_CHART_NAME=zenith-operator
 RUN helm pull ${ZENITH_APISERVER_CHART_NAME} \

--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -3,9 +3,4 @@ chart: ./chart
 images:
   azimuth-capi-operator:
     context: .
-    build_args:
-      HELM_VERSION: v3.13.2
-      # Use the latest stable version of the charts
-      OPENSTACK_CLUSTER_CHART_VERSION: ">=0.0.0"
-      ZENITH_CHART_VERSION: ">=0.0.0"
     chart_path: image


### PR DESCRIPTION
Using env in the GHA workflow file means that changes to those values are not actually tested, due to the use of `pull_request_target`. So move back to using build-arg defaults in the `Dockerfile`.

Needs https://github.com/stackhpc/github-actions/pull/7.