### PR TITLE
Allow HA and root volume to be specified in template

### DIFF
--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -19,13 +19,6 @@ class NodeGroupSpec(schema.BaseModel):
         ...,
         description = "The name of the size to use for the machines in the node group."
     )
-    root_volume_size: schema.conint(ge = 0) = Field(
-        0,
-        description = (
-            "The root volume size to use for machines in the node group. "
-            "If not given, the root disk from the flavor will be used."
-        )
-    )
     autoscale: bool = Field(
         False,
         description = "Whether the node group should autoscale or not."
@@ -136,17 +129,6 @@ class ClusterSpec(schema.BaseModel):
     control_plane_machine_size: schema.constr(min_length = 1) = Field(
         ...,
         description = "The name of the size to use for control plane machines."
-    )
-    ha_control_plane: bool = Field(
-        True,
-        description = "Indicates whether the control plane should be HA or not."
-    )
-    control_plane_root_volume_size: schema.conint(ge = 0) = Field(
-        0,
-        description = (
-            "The root volume size to use for control plane machines. "
-            "If not given, the root disk from the flavor will be used."
-        )
     )
     node_groups: t.List[NodeGroupSpec] = Field(
         default_factory = list,

--- a/azimuth_capi/templates/cluster-values.yaml
+++ b/azimuth_capi/templates/cluster-values.yaml
@@ -1,15 +1,6 @@
 cloudCredentialsSecretName: "{{ spec.cloud_credentials_secret_name }}"
 
 controlPlane:
-{% if spec.ha_control_plane %}
-  machineCount: 3
-{% else %}
-  machineCount: 1
-{% endif %}
-{% if spec.control_plane_root_volume_size %}
-  machineRootVolume:
-    diskSize: {{ spec.control_plane_root_volume_size }}
-{% endif %}
   machineFlavor: "{{ spec.control_plane_machine_size }}"
   healthCheck:
     enabled: {{ "true" if spec.autohealing else "false" }}
@@ -28,10 +19,6 @@ nodeGroups:
     machineCountMax: {{ node_group.max_count }}
 {% else %}
     machineCount: {{ node_group.count }}
-{% endif %}
-{% if node_group.root_volume_size %}
-    machineRootVolume:
-      diskSize: {{ node_group.root_volume_size }}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Prior to this change, the operator cannot control this through the template but there are no UI options for the user to control it either.

This change puts responsibility for configuring non-HA or root volumes back with the template.